### PR TITLE
fix typo in #define DEFAULT_FONT_PATH in config.h.in

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -21,7 +21,7 @@
 #define DEFAULT_FONT_TEXTURE_PATH "assets/fonts/font.png"
 #define DEFAULT_TIKZ_OUTPUT_FOLDER "tikz_output/"
 #else
-#define DEAULT_FONT_PATH "assets\\fonts\\" DEFAULT_FONT
+#define DEFAULT_FONT_PATH "assets\\fonts\\" DEFAULT_FONT
 #define DEFAULT_FONT_TEXTURE_PATH "assets\\fonts\\font.png"
 #define DEFAULT_TIKZ_OUTPUT_FOLDER "tikz_output\\"
 #endif


### PR DESCRIPTION
This pull request fixes a typo in [src/config.h.in#L24](https://github.com/tcosmo/simcqca/blob/master/src/config.h.in#L24)

* Fixed a typo in the macro `DEFAULT_FONT_PATH`, changing `DEAULT_FONT_PATH` to `DEFAULT_FONT_PATH`